### PR TITLE
removendo "Outras Remunerações Temporárias"

### DIFF
--- a/src/output_test/expected/expected_07_2019.json
+++ b/src/output_test/expected/expected_07_2019.json
@@ -59,12 +59,6 @@
                         "item": "Retenção por Teto Constitucional"
                     },
                     {
-                        "categoria": "contracheque",
-                        "item": "Outras Remunerações Temporárias",
-                        "valor": 29045.33,
-                        "tipoReceita": "O"
-                    },
-                    {
                         "categoria": "indenizações",
                         "item": "Auxílio-Saúde",
                         "valor": 2223.48,

--- a/src/parser.py
+++ b/src/parser.py
@@ -32,7 +32,6 @@ HEADERS = {
         "Contribuição Previdenciária": 10,
         "Imposto de Renda": 11,
         "Retenção por Teto Constitucional": 12,
-        "Outras Remunerações Temporárias": 14,
     },
     INDENIZACOES: {
         "Auxílio-Saúde": 4,


### PR DESCRIPTION
Essa coluna, presente na planilha de contracheques, é na realidade um somatório de outras remunerações presentes na planilha de indenizações.